### PR TITLE
Add interactive network background

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,12 @@
 </head>
 <body>
 
+    <div id="preloader">
+        <div class="loader"></div>
+    </div>
+
+    <canvas id="network"></canvas>
+
     <div class="container">
 
         <header class="hero">
@@ -78,5 +84,7 @@
             <p>&copy; 2025 Your Name</p>
         </footer>
 
-    </div> </body>
+    </div>
+    <script src="script.js"></script>
+</body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,90 @@
+window.addEventListener('load', () => {
+  const preloader = document.getElementById('preloader');
+  if (preloader) {
+    preloader.classList.add('fade-out');
+    setTimeout(() => {
+      preloader.style.display = 'none';
+    }, 600);
+  }
+});
+
+// Interactive particle network background
+const canvas = document.getElementById('network');
+if (canvas) {
+  const ctx = canvas.getContext('2d');
+  let width, height;
+  let particles = [];
+  const maxDistance = 120;
+
+  function resize() {
+    width = canvas.width = window.innerWidth;
+    height = canvas.height = window.innerHeight;
+    const count = Math.floor((width * height) / 8000);
+    particles = Array.from({ length: count }, () => ({
+      x: Math.random() * width,
+      y: Math.random() * height,
+      vx: (Math.random() - 0.5) * 0.7,
+      vy: (Math.random() - 0.5) * 0.7,
+    }));
+  }
+
+  let mouse = { x: null, y: null };
+
+  window.addEventListener('resize', resize);
+  window.addEventListener('mousemove', e => {
+    mouse.x = e.clientX;
+    mouse.y = e.clientY;
+  });
+  window.addEventListener('mouseleave', () => {
+    mouse.x = null;
+    mouse.y = null;
+  });
+
+  function update() {
+    ctx.clearRect(0, 0, width, height);
+    for (const p of particles) {
+      p.x += p.vx;
+      p.y += p.vy;
+
+      if (p.x < 0 || p.x > width) p.vx *= -1;
+      if (p.y < 0 || p.y > height) p.vy *= -1;
+
+      if (mouse.x !== null) {
+        const dx = p.x - mouse.x;
+        const dy = p.y - mouse.y;
+        const dist = Math.hypot(dx, dy);
+        if (dist < maxDistance) {
+          p.vx += dx * 0.0005;
+          p.vy += dy * 0.0005;
+        }
+      }
+
+      ctx.fillStyle = 'rgba(255,255,255,0.8)';
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, 2, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    for (let i = 0; i < particles.length; i++) {
+      for (let j = i + 1; j < particles.length; j++) {
+        const a = particles[i];
+        const b = particles[j];
+        const dx = a.x - b.x;
+        const dy = a.y - b.y;
+        const dist = Math.hypot(dx, dy);
+        if (dist < maxDistance) {
+          ctx.strokeStyle = `rgba(255,255,255,${1 - dist / maxDistance})`;
+          ctx.beginPath();
+          ctx.moveTo(a.x, a.y);
+          ctx.lineTo(b.x, b.y);
+          ctx.stroke();
+        }
+      }
+    }
+
+    requestAnimationFrame(update);
+  }
+
+  resize();
+  update();
+}

--- a/style.css
+++ b/style.css
@@ -19,6 +19,48 @@ body {
     -moz-osx-font-smoothing: grayscale;
 }
 
+/* --- Animated Background --- */
+#network {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+    z-index: -1;
+    background: linear-gradient(120deg, #3a1c71, #d76d77, #ffaf7b);
+}
+
+/* --- Preloader --- */
+#preloader {
+    position: fixed;
+    inset: 0;
+    background: #f5f5f7;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 9999;
+    transition: opacity 0.6s ease, visibility 0s linear 0.6s;
+}
+
+#preloader.fade-out {
+    opacity: 0;
+    visibility: hidden;
+}
+
+.loader {
+    width: 60px;
+    height: 60px;
+    border: 4px solid #007aff;
+    border-top-color: transparent;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
 /* --- Layout Container --- */
 .container {
     max-width: 900px; /* Slightly wider for card layout */


### PR DESCRIPTION
## Summary
- add a full-screen canvas for the animated background
- style the canvas with a gradient and place it behind the page
- implement a particle network that reacts to cursor movement

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685aabc9f4cc832aa08b8061d02d4cda